### PR TITLE
Update index.md

### DIFF
--- a/index.md
+++ b/index.md
@@ -21,6 +21,7 @@ PSP Certification recognizes companies that are prioritizing open podcasting tec
 - Blubrry
 - Buzzsprout
 - Captivate
+- CastGarden
 - Fireside
 - RedCircle
 - RSS


### PR DESCRIPTION
Added CastGarden to list of PSP Certified hosts. 
https://github.com/Podcast-Standards-Project/Certification/issues/5 